### PR TITLE
fix: rustc 1.69よりtracing_subscriberにて正規表現エラーが出る問題の暫定対応

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "1.4.0"
 chrono = {version = "0.4.23", features = ["serde"]}
 dotenv = "0.15.0"
 envy = "0.4.2"
+fern = {version = "0.6.2", features = ["colored"]}
 futures = {version = "0.3.26"}
 gloo = {version = "0.8.0", features = ["futures"]}
 log = "0.4.17"

--- a/src/bin/ssr_server.rs
+++ b/src/bin/ssr_server.rs
@@ -16,7 +16,7 @@ use axum::routing::get;
 use axum::{Extension, Router};
 use blog_romira_dev::prelude::{ServerApp, ServerAppProps};
 use blog_romira_dev::routes::Route;
-use blog_romira_dev::settings::CONFIG;
+use blog_romira_dev::settings::{init_logger, CONFIG};
 use clap::Parser;
 use futures::stream::{self, StreamExt};
 use hyper::server::Server;
@@ -125,11 +125,12 @@ where
 async fn main() -> Result<(), Err> {
     let opts = Opt::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| CONFIG.rust_log().into()),
-        )
-        .try_init()?;
+    // tracing_subscriber::fmt()
+    //     .with_env_filter(
+    //         EnvFilter::try_from_default_env().unwrap_or_else(|_| CONFIG.rust_log().into()),
+    //     )
+    //     .try_init()?;
+    init_logger(CONFIG.rust_log_to_log_level_filter(), None)?;
 
     let exec = Executor::default();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use fern::colors::{Color, ColoredLevelConfig};
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 
@@ -26,7 +27,7 @@ impl Config {
         &&self.newt_api_token
     }
 
-    pub fn rust_log_to_level_filter(&self) -> log::LevelFilter {
+    pub fn rust_log_to_log_level_filter(&self) -> log::LevelFilter {
         match self.rust_log.to_lowercase().as_str() {
             "error" => log::LevelFilter::Error,
             "warn" => log::LevelFilter::Warn,
@@ -43,53 +44,53 @@ pub static CONFIG: Lazy<Config> = Lazy::new(|| {
     envy::from_env().expect("Failed to env to Config.")
 });
 
-// pub fn init_logger(
-//     log_level: log::LevelFilter,
-//     log_file_path: Option<PathBuf>,
-// ) -> Result<(), fern::InitError> {
-//     let colors = ColoredLevelConfig::new()
-//         .info(Color::Green)
-//         .trace(Color::BrightBlack);
+pub fn init_logger(
+    log_level: log::LevelFilter,
+    log_file_path: Option<PathBuf>,
+) -> Result<(), fern::InitError> {
+    let colors = ColoredLevelConfig::new()
+        .info(Color::Green)
+        .trace(Color::BrightBlack);
 
-//     let base_config = fern::Dispatch::new()
-//         .level(log_level)
-//         .level_for("axum", log::LevelFilter::Info)
-//         .level_for("hyper", log::LevelFilter::Info)
-//         .level_for("tower-http", log::LevelFilter::Info)
-//         .level_for("tower", log::LevelFilter::Info);
+    let base_config = fern::Dispatch::new()
+        .level(log_level)
+        .level_for("axum", log::LevelFilter::Info)
+        .level_for("hyper", log::LevelFilter::Info)
+        .level_for("tower-http", log::LevelFilter::Info)
+        .level_for("tower", log::LevelFilter::Info);
 
-//     let stdout_config = fern::Dispatch::new()
-//         .format(move |out, message, record| {
-//             out.finish(format_args!(
-//                 "{}[{}][{}] {}",
-//                 chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
-//                 record.target(),
-//                 colors.color(record.level()),
-//                 message
-//             ))
-//         })
-//         .chain(std::io::stdout());
+    let stdout_config = fern::Dispatch::new()
+        .format(move |out, message, record| {
+            out.finish(format_args!(
+                "{}[{}][{}] {}",
+                chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
+                record.target(),
+                colors.color(record.level()),
+                message
+            ))
+        })
+        .chain(std::io::stdout());
 
-//     let file_config = if let Some(log_file_path) = log_file_path {
-//         fern::Dispatch::new()
-//             .format(|out, message, record| {
-//                 out.finish(format_args!(
-//                     "{}[{}][{}] {}",
-//                     chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
-//                     record.target(),
-//                     record.level(),
-//                     message
-//                 ))
-//             })
-//             .chain(fern::log_file(log_file_path)?)
-//     } else {
-//         fern::Dispatch::new()
-//     };
+    let file_config = if let Some(log_file_path) = log_file_path {
+        fern::Dispatch::new()
+            .format(|out, message, record| {
+                out.finish(format_args!(
+                    "{}[{}][{}] {}",
+                    chrono::Local::now().format("[%Y-%m-%d %H:%M:%S]"),
+                    record.target(),
+                    record.level(),
+                    message
+                ))
+            })
+            .chain(fern::log_file(log_file_path)?)
+    } else {
+        fern::Dispatch::new()
+    };
 
-//     base_config
-//         .chain(stdout_config)
-//         .chain(file_config)
-//         .apply()?;
+    base_config
+        .chain(stdout_config)
+        .chain(file_config)
+        .apply()?;
 
-//     Ok(())
-// }
+    Ok(())
+}


### PR DESCRIPTION
tracing_subscriberに使われているregexでエラーが発生するため，
暫定対応としてtracing_subscriberの使用を中止し，fernをロガーとして使用する．

rustc 1.69
